### PR TITLE
Change ant visuals

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -33,6 +33,14 @@ export const ANT_RADIUS = {
   queen: 6
 };
 
+/* ---------- Team colors ---------- */
+export const TEAM_COLORS = [
+  '#90EE90', // Team 0 - light green
+  '#FF6B6B', // Team 1 - light red
+  '#6BA8FF', // Team 2 - light blue
+  '#FFD700'  // Team 3 - gold
+];
+
 /* ---------- Helpers ---------- */
 export function dist(a, b) {
   const dx = a.x - b.x;

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -23,6 +23,16 @@ export const ANT_STATS = {
   queen:    { hp: 500, dmg: 0, range: 0, speed: 0 }
 };
 
+/* ---------- Ant visual size ---------- */
+export const ANT_RADIUS = {
+  worker: 3,
+  private: 4,
+  general: 5,
+  artillery: 4,
+  defender: 4,
+  queen: 6
+};
+
 /* ---------- Helpers ---------- */
 export function dist(a, b) {
   const dx = a.x - b.x;

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -6,7 +6,7 @@ import { Ant } from './ant.js';
 import { cleanupDead } from './combat.js';
 import { runAI } from './ai.js';
 import { updateUI, bindButtons } from './ui.js';
-import { TILE, MAP_W, MAP_H, ANT_COST, DEBUG, ANT_RADIUS } from './constants.js';
+import { TILE, MAP_W, MAP_H, ANT_COST, DEBUG, ANT_RADIUS, TEAM_COLORS } from './constants.js';
 import { addDamageText, updateFX, drawFX } from './fx.js';
 import { click } from './audio.js';
 
@@ -15,13 +15,7 @@ const PALETTE = {
   dirt:   '#6B4423',
   grass:  '#3A5F0B',
   dgrass: '#2B4708',
-  nest:   '#8B4513',
-  queen:  '#90EE90',
-  worker: '#90EE90',
-  private:'#90EE90',
-  general:'#90EE90',
-  artillery:'#90EE90',
-  defender:'#90EE90'
+  nest:   '#8B4513'
 };
 
 /* ---------- Canvas ---------- */
@@ -106,7 +100,7 @@ function drawAnt(a) {
   ctx.translate(px, py);
 
   // body
-  ctx.fillStyle = PALETTE[a.type] || '#FFF';
+  ctx.fillStyle = TEAM_COLORS[a.team] || '#FFF';
   ctx.beginPath();
   ctx.arc(0, 0, ANT_RADIUS[a.type] || 4, 0, Math.PI * 2);
   ctx.fill();

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -6,7 +6,7 @@ import { Ant } from './ant.js';
 import { cleanupDead } from './combat.js';
 import { runAI } from './ai.js';
 import { updateUI, bindButtons } from './ui.js';
-import { TILE, MAP_W, MAP_H, ANT_COST, DEBUG } from './constants.js';
+import { TILE, MAP_W, MAP_H, ANT_COST, DEBUG, ANT_RADIUS } from './constants.js';
 import { addDamageText, updateFX, drawFX } from './fx.js';
 import { click } from './audio.js';
 
@@ -16,12 +16,12 @@ const PALETTE = {
   grass:  '#3A5F0B',
   dgrass: '#2B4708',
   nest:   '#8B4513',
-  queen:  '#FFD700',
+  queen:  '#90EE90',
   worker: '#90EE90',
-  private:'#FF0000',
-  general:'#0000FF',
-  artillery:'#800080',
-  defender:'#ADD8E6'
+  private:'#90EE90',
+  general:'#90EE90',
+  artillery:'#90EE90',
+  defender:'#90EE90'
 };
 
 /* ---------- Canvas ---------- */
@@ -108,7 +108,7 @@ function drawAnt(a) {
   // body
   ctx.fillStyle = PALETTE[a.type] || '#FFF';
   ctx.beginPath();
-  ctx.arc(0, 0, 4, 0, Math.PI * 2);
+  ctx.arc(0, 0, ANT_RADIUS[a.type] || 4, 0, Math.PI * 2);
   ctx.fill();
 
   // simple legs (2-frame walk)


### PR DESCRIPTION
## Summary
- add ANT_RADIUS mapping for visual sizes
- unify ant palette color
- draw ants using ANT_RADIUS

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68816912934c83238909eb88a75ddc03