### PR TITLE
Show player unit counts at game over

### DIFF
--- a/play.html
+++ b/play.html
@@ -39,6 +39,7 @@
   <!-- Game-Over overlay -->
   <div id="overlay" class="hidden">
     <h2 id="overlayText"></h2>
+    <div id="overlayStats"></div>
     <button id="restartBtn">Restart</button>
   </div>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -113,3 +113,8 @@ body#startBody {
   padding:8px 18px;
   font-size:1rem;
 }
+#overlayStats {
+  font-size:1.2rem;
+  margin-top:10px;
+  text-align:center;
+}

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -144,6 +144,15 @@ function checkWinLoss() {
 
 function showGameOver(text) {
   document.getElementById('overlayText').textContent = text;
+  const statsDiv = document.getElementById('overlayStats');
+  const counts = {};
+  gameState.ants
+    .filter(a => a.team === 0 && !a.dead)
+    .forEach(a => counts[a.type] = (counts[a.type] || 0) + 1);
+  const lines = Object.keys(counts)
+    .sort()
+    .map(type => `${type.charAt(0).toUpperCase() + type.slice(1)}: ${counts[type]}`);
+  statsDiv.innerHTML = lines.join('<br>');
   document.getElementById('overlay').classList.remove('hidden');
 }
 


### PR DESCRIPTION
## Summary
- display a stats container in the game-over overlay
- style stats text
- compute and show counts of each surviving player unit when the game ends

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68816bafbe348323921e5c643387fd23