### PR TITLE
Fix game over stats error

### DIFF
--- a/src/js/play.js
+++ b/src/js/play.js
@@ -145,14 +145,16 @@ function checkWinLoss() {
 function showGameOver(text) {
   document.getElementById('overlayText').textContent = text;
   const statsDiv = document.getElementById('overlayStats');
-  const counts = {};
-  gameState.ants
-    .filter(a => a.team === 0 && !a.dead)
-    .forEach(a => counts[a.type] = (counts[a.type] || 0) + 1);
-  const lines = Object.keys(counts)
-    .sort()
-    .map(type => `${type.charAt(0).toUpperCase() + type.slice(1)}: ${counts[type]}`);
-  statsDiv.innerHTML = lines.join('<br>');
+  if (statsDiv) {
+    const counts = {};
+    gameState.ants
+      .filter(a => a.team === 0 && !a.dead)
+      .forEach(a => counts[a.type] = (counts[a.type] || 0) + 1);
+    const lines = Object.keys(counts)
+      .sort()
+      .map(type => `${type.charAt(0).toUpperCase() + type.slice(1)}: ${counts[type]}`);
+    statsDiv.innerHTML = lines.join('<br>');
+  }
   document.getElementById('overlay').classList.remove('hidden');
 }
 


### PR DESCRIPTION
## Summary
- check for overlayStats element before updating

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68816d373f0883238c4ed39c8dd9df74