### PR TITLE
Fix double-tap zoom

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -15,6 +15,7 @@ body {
   font-family:sans-serif;
   color:#fff;
   min-width:800px;
+  touch-action: manipulation;
 }
 
 .ui-panel {


### PR DESCRIPTION
## Summary
- prevent double-tap zoom while keeping pinch zoom working

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68816d9075f083238e22622a38ffeaef