### PR TITLE
Add dead ant tracking to statistics

### DIFF
--- a/src/js/combat.js
+++ b/src/js/combat.js
@@ -1,5 +1,12 @@
 import { gameState } from './entities.js';
 
 export function cleanupDead() {
-  gameState.ants = gameState.ants.filter(a => !a.dead);
+  gameState.ants = gameState.ants.filter(a => {
+    if (a.dead) {
+      if (!gameState.deadAnts) gameState.deadAnts = [0, 0, 0, 0];
+      gameState.deadAnts[a.team] = (gameState.deadAnts[a.team] || 0) + 1;
+      return false;
+    }
+    return true;
+  });
 }

--- a/src/js/entities.js
+++ b/src/js/entities.js
@@ -7,5 +7,6 @@ export const gameState = {
   ],
   ants: [],
   resources: [],
-  pheromones: []  // flat array [{x,y,team,strength}]
+  pheromones: [], // flat array [{x,y,team,strength}]
+  deadAnts: [0, 0, 0, 0]
 };

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -153,6 +153,8 @@ function showGameOver(text) {
     const lines = Object.keys(counts)
       .sort()
       .map(type => `${type.charAt(0).toUpperCase() + type.slice(1)}: ${counts[type]}`);
+    const dead = gameState.deadAnts ? gameState.deadAnts[0] : 0;
+    lines.push(`Dead ants: ${dead}`);
     statsDiv.innerHTML = lines.join('<br>');
   }
   document.getElementById('overlay').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- track dead ants for each team in game state
- count ant deaths when cleaning up dead units
- show "Dead ants" in the game over statistics

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68817070a6ec8323b73fa9f2094e9ca2