### PR TITLE
Implement lifetime ant stats

### DIFF
--- a/src/js/ant.js
+++ b/src/js/ant.js
@@ -28,6 +28,11 @@ export class Ant {
     this.wanderDirY = (this.rand() - 0.5) * 2;
     this.lastSugarResource = null;
     this.lastAttackTime = 0;
+
+    // track total ants spawned
+    if (!gameState.totalAnts) gameState.totalAnts = [{}, {}, {}, {}];
+    const totals = gameState.totalAnts[team];
+    totals[type] = (totals[type] || 0) + 1;
   }
 
   /* ---------- Main update ---------- */

--- a/src/js/entities.js
+++ b/src/js/entities.js
@@ -8,5 +8,7 @@ export const gameState = {
   ants: [],
   resources: [],
   pheromones: [], // flat array [{x,y,team,strength}]
-  deadAnts: [0, 0, 0, 0]
+  deadAnts: [0, 0, 0, 0],
+  // track total ants spawned per team and type
+  totalAnts: [{}, {}, {}, {}]
 };

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -128,11 +128,8 @@ function drawAnt(a) {
 let playerFinalStats = null;
 
 function getPlayerStats() {
-  const counts = {};
-  gameState.ants
-    .filter(a => a.team === 0 && !a.dead)
-    .forEach(a => counts[a.type] = (counts[a.type] || 0) + 1);
-  return counts;
+  if (!gameState.totalAnts) return {};
+  return { ...gameState.totalAnts[0] };
 }
 
 function checkWinLoss() {


### PR DESCRIPTION
## Summary
- record cumulative ant spawns in game state
- increment totals when ants are created
- show lifetime counts on the game over screen

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6881721176088323bfc5b8b6fe5e493f