### PR TITLE
Improve stats overlay

### DIFF
--- a/src/js/play.js
+++ b/src/js/play.js
@@ -161,9 +161,10 @@ function showGameOver(text, counts) {
   const statsDiv = document.getElementById('overlayStats');
   if (statsDiv) {
     const stats = counts || getPlayerStats();
-    const lines = Object.keys(stats)
-      .sort()
-      .map(type => `${type.charAt(0).toUpperCase() + type.slice(1)}: ${stats[type]}`);
+    const types = ['worker', 'private', 'general', 'artillery', 'defender', 'queen'];
+    const lines = types.map(type =>
+      `${type.charAt(0).toUpperCase() + type.slice(1)}: ${stats[type] || 0}`
+    );
     const dead = gameState.deadAnts ? gameState.deadAnts[0] : 0;
     lines.push(`Dead ants: ${dead}`);
     statsDiv.innerHTML = lines.join('<br>');


### PR DESCRIPTION
## Summary
- list all ant types in the end-game statistics overlay
- show `0` for ant types that were never spawned

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688173d8d58c8323a45d7abcdfd54ddf