### PR TITLE
Scale ant size by max HP

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -23,6 +23,14 @@ export const ANT_STATS = {
   queen:    { hp: 500, dmg: 0, range: 0, speed: 0 }
 };
 
+/*
+ * Compute a visual radius for an ant given its total hit points. This uses a
+ * logarithmic scale so high HP ants appear larger without becoming gigantic.
+ */
+export function radiusFromHP(hp) {
+  return 1 + 2 * Math.log10(hp);
+}
+
 /* ---------- Ant visual size ---------- */
 export const ANT_RADIUS = {
   worker: 3,

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -6,7 +6,7 @@ import { Ant } from './ant.js';
 import { cleanupDead } from './combat.js';
 import { runAI } from './ai.js';
 import { updateUI, bindButtons } from './ui.js';
-import { TILE, MAP_W, MAP_H, ANT_COST, DEBUG, ANT_RADIUS, TEAM_COLORS } from './constants.js';
+import { TILE, MAP_W, MAP_H, ANT_COST, DEBUG, radiusFromHP, TEAM_COLORS } from './constants.js';
 import { addDamageText, updateFX, drawFX } from './fx.js';
 import { click } from './audio.js';
 
@@ -102,7 +102,8 @@ function drawAnt(a) {
   // body
   ctx.fillStyle = TEAM_COLORS[a.team] || '#FFF';
   ctx.beginPath();
-  ctx.arc(0, 0, ANT_RADIUS[a.type] || 4, 0, Math.PI * 2);
+  const radius = radiusFromHP(a.maxHp);
+  ctx.arc(0, 0, radius, 0, Math.PI * 2);
   ctx.fill();
 
   // simple legs (2-frame walk)


### PR DESCRIPTION
## Summary
- compute ant radius from max HP using new helper
- use the function when drawing ants

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68830e111ba883239bcb2f6a6d3356d9