### PR TITLE
Add 6-leg ants

### DIFF
--- a/src/js/play.js
+++ b/src/js/play.js
@@ -110,11 +110,18 @@ function drawAnt(a) {
   ctx.strokeStyle = '#000';
   ctx.lineWidth = 1;
   const r = ANT_RADIUS[a.type] || 4;
-  [[-r,  wiggle], [r, -wiggle]].forEach(([dx, dy]) => {
-    ctx.beginPath();
-    ctx.moveTo(dx, dy);
-    ctx.lineTo(dx * 2, dy * 2);
-    ctx.stroke();
+
+  // draw three pairs of legs with slight diagonal offsets
+  const legAngles = [0, Math.PI / 4, -Math.PI / 4];
+  legAngles.forEach(angle => {
+    [-1, 1].forEach(side => {
+      const dx = Math.cos(angle) * r * side;
+      const dy = Math.sin(angle) * r + wiggle * side;
+      ctx.beginPath();
+      ctx.moveTo(dx, dy);
+      ctx.lineTo(dx * 2, dy * 2);
+      ctx.stroke();
+    });
   });
 
   ctx.restore();

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -112,7 +112,8 @@ function drawAnt(a) {
   const r = ANT_RADIUS[a.type] || 4;
 
   // draw three pairs of legs with slight diagonal offsets
-  const legAngles = [0, Math.PI / 4, -Math.PI / 4];
+  // keep the diagonal legs closer to the middle pair
+  const legAngles = [0, Math.PI / 8, -Math.PI / 8];
   legAngles.forEach(angle => {
     [-1, 1].forEach(side => {
       const dx = Math.cos(angle) * r * side;


### PR DESCRIPTION
## Summary
- draw ants with 3 pairs of legs instead of only one pair

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688313c99724832394aab23d07896884