### PR TITLE
Add ant outline

### DIFF
--- a/src/js/play.js
+++ b/src/js/play.js
@@ -104,6 +104,9 @@ function drawAnt(a) {
   ctx.beginPath();
   ctx.arc(0, 0, ANT_RADIUS[a.type] || 4, 0, Math.PI * 2);
   ctx.fill();
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = 1;
+  ctx.stroke();
 
   // simple legs (2-frame walk)
   const wiggle = Math.sin(performance.now() * 0.01 * a.speed * 100) * 2;


### PR DESCRIPTION
## Summary
- outline ant bodies in `drawAnt`

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688316ccdc84832397cc0570c1949f63