### PR TITLE
Draw ants with oval bodies

### DIFF
--- a/src/js/play.js
+++ b/src/js/play.js
@@ -124,18 +124,20 @@ function drawAnt(a) {
   ctx.strokeStyle = '#000';
   ctx.lineWidth = 1;
 
-  // draw three pairs of legs with slight diagonal offsets
-  // keep the diagonal legs closer to the middle pair
+  // draw three pairs of legs that radiate from the long side of the body
   const legAngles = [0, Math.PI / 8, -Math.PI / 8];
-  // legs originate from the rear of the body
-  const legAnchorX = -bodyW;
-  legAngles.forEach(angle => {
+  const legOffsets = [-bodyH * 0.5, 0, bodyH * 0.5];
+  const legLen = bodyW * 0.7;
+  legAngles.forEach((angle, i) => {
+    const offsetY = legOffsets[i];
     [-1, 1].forEach(side => {
-      const startY = Math.cos(angle) * r * side;
-      const endY = startY + Math.sin(angle) * r * side + wiggle * side;
+      const anchorX = bodyW * side;
+      const anchorY = offsetY;
+      const dx = Math.cos(angle) * legLen * side;
+      const dy = Math.sin(angle) * legLen * side + wiggle * side;
       ctx.beginPath();
-      ctx.moveTo(legAnchorX, startY);
-      ctx.lineTo(legAnchorX - bodyW * 0.5, endY);
+      ctx.moveTo(anchorX, anchorY);
+      ctx.lineTo(anchorX + dx, anchorY + dy);
       ctx.stroke();
     });
   });

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -98,6 +98,8 @@ function drawAnt(a) {
   const py = a.y * TILE;
   ctx.save();
   ctx.translate(px, py);
+  // rotate so the head faces up
+  ctx.rotate(-Math.PI / 2);
 
   // body: an oval where the legs attach
   ctx.fillStyle = TEAM_COLORS[a.team] || '#FFF';
@@ -125,13 +127,15 @@ function drawAnt(a) {
   // draw three pairs of legs with slight diagonal offsets
   // keep the diagonal legs closer to the middle pair
   const legAngles = [0, Math.PI / 8, -Math.PI / 8];
+  // legs originate from the rear of the body
+  const legAnchorX = -bodyW;
   legAngles.forEach(angle => {
     [-1, 1].forEach(side => {
-      const dx = Math.cos(angle) * bodyW * side;
-      const dy = Math.sin(angle) * r + wiggle * side;
+      const startY = Math.cos(angle) * r * side;
+      const endY = startY + Math.sin(angle) * r * side + wiggle * side;
       ctx.beginPath();
-      ctx.moveTo(dx, dy);
-      ctx.lineTo(dx * 1.5, dy * 2);
+      ctx.moveTo(legAnchorX, startY);
+      ctx.lineTo(legAnchorX - bodyW * 0.5, endY);
       ctx.stroke();
     });
   });

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -99,31 +99,39 @@ function drawAnt(a) {
   ctx.save();
   ctx.translate(px, py);
 
-  // body
+  // body: an oval where the legs attach
   ctx.fillStyle = TEAM_COLORS[a.team] || '#FFF';
+  const r = ANT_RADIUS[a.type] || 4;
+  const bodyW = r * 1.5; // width of the oval
+  const bodyH = r;       // height of the oval
   ctx.beginPath();
-  ctx.arc(0, 0, ANT_RADIUS[a.type] || 4, 0, Math.PI * 2);
+  ctx.ellipse(0, 0, bodyW, bodyH, 0, 0, Math.PI * 2);
   ctx.fill();
   ctx.strokeStyle = '#000';
   ctx.lineWidth = 1;
+  ctx.stroke();
+
+  // head: a smaller circle at the front
+  ctx.beginPath();
+  ctx.arc(bodyW, 0, r * 0.75, 0, Math.PI * 2);
+  ctx.fill();
   ctx.stroke();
 
   // simple legs (2-frame walk)
   const wiggle = Math.sin(performance.now() * 0.01 * a.speed * 100) * 2;
   ctx.strokeStyle = '#000';
   ctx.lineWidth = 1;
-  const r = ANT_RADIUS[a.type] || 4;
 
   // draw three pairs of legs with slight diagonal offsets
   // keep the diagonal legs closer to the middle pair
   const legAngles = [0, Math.PI / 8, -Math.PI / 8];
   legAngles.forEach(angle => {
     [-1, 1].forEach(side => {
-      const dx = Math.cos(angle) * r * side;
+      const dx = Math.cos(angle) * bodyW * side;
       const dy = Math.sin(angle) * r + wiggle * side;
       ctx.beginPath();
       ctx.moveTo(dx, dy);
-      ctx.lineTo(dx * 2, dy * 2);
+      ctx.lineTo(dx * 1.5, dy * 2);
       ctx.stroke();
     });
   });


### PR DESCRIPTION
## Summary
- tweak `drawAnt` to paint an oval body and a separate head, each outlined in black
- adjust leg start points for the new body shape

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68831ad3683083239875518cbfb541a1