### PR TITLE
Move ant size into stats

### DIFF
--- a/src/js/ant.js
+++ b/src/js/ant.js
@@ -1,6 +1,6 @@
 /* ---------- Imports ---------- */
 import { gameState } from './entities.js';
-import { dist, TILE, MAP_W, MAP_H, ANT_STATS, DEBUG, ANT_RADIUS, TEAM_COLORS } from './constants.js';
+import { dist, TILE, MAP_W, MAP_H, ANT_STATS, DEBUG, TEAM_COLORS } from './constants.js';
 import { addPheromone, getPheromone } from './pheromone.js';
 import * as prng from './prng.js';
 import { addDamageText } from './fx.js';
@@ -303,7 +303,7 @@ export class Ant {
     // body
     ctx.fillStyle = TEAM_COLORS[this.team] || '#FFF';
     ctx.beginPath();
-    const bodyR = ANT_RADIUS[this.type] || 4;
+    const bodyR = this.size || 4;
     const bodyRx = bodyR * 0.6; // flat width
     const bodyRy = bodyR * 1.2; // elongated height
     ctx.ellipse(0, 0, bodyRx, bodyRy, 0, 0, Math.PI * 2);

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -15,23 +15,14 @@ export const ANT_COST = {
 
 /* ---------- Unit stats ---------- */
 export const ANT_STATS = {
-  worker:   { hp: 10, dmg: 0, range: 0, speed: 0.050, attackSpeed: 100 },
-  private:  { hp: 25, dmg: 5, range: 1, speed: 0.045, attackSpeed: 100 },
-  general:  { hp: 90, dmg: 20, range: 1, speed: 0.022, attackSpeed: 200 },
-  artillery:{ hp: 20, dmg: 10, range: 9, speed: 0.028, attackSpeed: 150 },
-  defender: { hp: 300, dmg: 10, range: 1, speed: 0.015, attackSpeed: 200 },
-  queen:    { hp: 500, dmg: 0, range: 0, speed: 0 }
+  worker:   { hp: 10, dmg: 0, range: 0, speed: 0.050, attackSpeed: 100, size: 1 },
+  private:  { hp: 25, dmg: 5, range: 1, speed: 0.045, attackSpeed: 100, size: 3 },
+  general:  { hp: 90, dmg: 20, range: 1, speed: 0.022, attackSpeed: 200, size: 4 },
+  artillery:{ hp: 20, dmg: 10, range: 9, speed: 0.028, attackSpeed: 150, size: 2 },
+  defender: { hp: 300, dmg: 10, range: 1, speed: 0.015, attackSpeed: 200, size: 5 },
+  queen:    { hp: 500, dmg: 0, range: 0, speed: 0,                size: 6 }
 };
 
-/* ---------- Ant visual size ---------- */
-export const ANT_RADIUS = {
-  worker: 1,
-  private: 3,
-  general: 4,
-  artillery: 2,
-  defender: 5,
-  queen: 6
-};
 
 /* ---------- Team colors ---------- */
 export const TEAM_COLORS = [


### PR DESCRIPTION
## Summary
- simplify ant constants
- store size within `ANT_STATS`
- update draw code to use instance size

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68832fe5f344832387b46d98df1af854