### PR TITLE
Enable AI demo behind start screen

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -87,6 +87,11 @@ body#startBody {
   color:#fff;
 }
 #startScreen {
+  position:fixed;
+  top:50%;
+  left:50%;
+  transform:translate(-50%, -50%);
+  z-index:5;
   background:#000c;
   padding:30px 40px;
   border-radius:8px;

--- a/src/js/ai.js
+++ b/src/js/ai.js
@@ -7,7 +7,7 @@ let lastAttack = [0, 0, 0, 0];
 
 export function runAI(delta) {
   gameState.teams.forEach((team, tid) => {
-    if (tid === 0) return; // skip human
+    if (!window.demoMode && tid === 0) return; // skip human unless demo
 
     // Skip AI actions if the team's queen is dead
     const queenAlive = gameState.ants.some(

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -115,6 +115,12 @@ function checkWinLoss() {
   const alive = gameState.teams.filter(t =>
     gameState.ants.some(a => a.type === 'queen' && a.team === t.id && !a.dead)
   );
+
+  if (window.demoMode && alive.length <= 1) {
+    location.reload();
+    return;
+  }
+
   if (alive.length === 1) {
     if (alive[0].id === 0) {
       showGameOver('You Win!');

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -127,6 +127,7 @@ function checkWinLoss() {
 }
 
 function showGameOver(text, counts) {
+  if (window.demoMode) return;
   document.getElementById('overlayText').textContent = text;
   const statsDiv = document.getElementById('overlayStats');
   if (statsDiv) {

--- a/src/js/start.js
+++ b/src/js/start.js
@@ -2,11 +2,17 @@ const seedInput = document.getElementById('seedInput');
 const randomBtn = document.getElementById('randomBtn');
 const startBtn  = document.getElementById('startBtn');
 
+// Show a demo match using AI for all teams
+window.demoMode = true;
+document.getElementById('gameArea').classList.remove('hidden');
+import('./play.js');
+
 randomBtn.onclick = () => {
   seedInput.value = Math.floor(Math.random() * 999999);
 };
 
 startBtn.onclick = async () => {
+  window.demoMode = false;
   const seed = seedInput.value || 12345;
   sessionStorage.setItem('qantSeed', seed);
   document.getElementById('startScreen').classList.add('hidden');


### PR DESCRIPTION
## Summary
- autoplay demo match behind start screen
- allow AI to control the player team during the demo

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883486175888323ba9639b5ca6f4757