### PR TITLE
Show UI stats in demo mode

### DIFF
--- a/src/js/start.js
+++ b/src/js/start.js
@@ -4,7 +4,8 @@ const startBtn  = document.getElementById('startBtn');
 
 // Show a demo match using AI for all teams
 window.demoMode = true;
-document.getElementById('gameArea').classList.remove('hidden');
+['gameArea', 'ui-team-0', 'ui-team-1', 'ui-team-2', 'ui-team-3']
+  .forEach(id => document.getElementById(id).classList.remove('hidden'));
 import('./play.js');
 
 randomBtn.onclick = () => {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -11,13 +11,13 @@ export function updateUI() {
   const playerQueen = gameState.ants.find(a => a.team === 0 && a.type === 'queen');
   $('playerQueenHp').textContent = playerQueen ? playerQueen.hp.toFixed(0) : 'N/A';
 
-  // disable buttons if not enough sugar
+  // disable buttons if not enough sugar or in demo mode
   const playerQueenAlive = gameState.ants.some(a => a.team === 0 && a.type === 'queen' && !a.dead);
   Object.keys(ANT_COST).forEach(type => {
     $(`btn${type.charAt(0).toUpperCase() + type.slice(1)}`).disabled =
-      playerTeam.sugar < ANT_COST[type] || !playerQueenAlive;
+      window.demoMode || playerTeam.sugar < ANT_COST[type] || !playerQueenAlive;
   });
-  $('btnAttack').disabled = !playerQueenAlive;
+  $('btnAttack').disabled = window.demoMode || !playerQueenAlive;
 
   // AI team stats
   gameState.teams.forEach(team => {
@@ -47,9 +47,9 @@ export function bindButtons(spawnFn, attackFn) {
   $('btnArtillery').onclick = () => spawnFn('artillery');
   $('btnDefender').onclick  = () => spawnFn('defender');
   $('btnAttack').onclick    = attackFn;
-  // Disable buttons if queen is dead
+  // Disable buttons if queen is dead or during demo
   const playerQueenAlive = gameState.ants.some(a => a.team === 0 && a.type === 'queen' && !a.dead);
-  if (!playerQueenAlive) {
+  if (!playerQueenAlive || window.demoMode) {
     Object.keys(ANT_COST).forEach(type => {
       $(`btn${type.charAt(0).toUpperCase() + type.slice(1)}`).disabled = true;
     });


### PR DESCRIPTION
## Summary
- display team UI panels during autoplay demo
- disable purchasing and attack buttons while demo is running

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883532ef1e88323812fb59e4056a376