### PR TITLE
Restart demo when seed changes

### DIFF
--- a/src/js/start.js
+++ b/src/js/start.js
@@ -2,6 +2,17 @@ const seedInput = document.getElementById('seedInput');
 const randomBtn = document.getElementById('randomBtn');
 const startBtn  = document.getElementById('startBtn');
 
+// use any stored seed on reloads
+seedInput.value = sessionStorage.getItem('qantSeed') || '';
+
+function updateSeedAndRestart() {
+  const seed = seedInput.value || 12345;
+  sessionStorage.setItem('qantSeed', seed);
+  if (window.demoMode) {
+    location.reload();
+  }
+}
+
 // Show a demo match using AI for all teams
 window.demoMode = true;
 ['gameArea', 'ui-team-0', 'ui-team-1', 'ui-team-2', 'ui-team-3']
@@ -10,7 +21,10 @@ import('./play.js');
 
 randomBtn.onclick = () => {
   seedInput.value = Math.floor(Math.random() * 999999);
+  updateSeedAndRestart();
 };
+
+seedInput.addEventListener('change', updateSeedAndRestart);
 
 startBtn.onclick = async () => {
   window.demoMode = false;


### PR DESCRIPTION
## Summary
- refresh stored map seed when the seed input changes
- reload the page to regenerate the map in demo mode

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68835abf6adc8323bc69be6cb33e9d20