### PR TITLE
Fix ant health floor

### DIFF
--- a/src/js/ant.js
+++ b/src/js/ant.js
@@ -286,10 +286,10 @@ export class Ant {
     }
 
     if (target.hp !== undefined) {
-      const dmg = this.dmg;
+      const dmg = Math.min(this.dmg, target.hp);
       target.hp -= dmg;
-      addDamageText(target.x, target.y, dmg);
       this.lastAttackTime = performance.now();
+      addDamageText(target.x, target.y, dmg);
     }
   }
 

--- a/tests/ant.test.js
+++ b/tests/ant.test.js
@@ -1,0 +1,10 @@
+import { Ant } from '../src/js/ant.js';
+import { gameState } from '../src/js/entities.js';
+
+test('ant attack does not reduce hp below zero', () => {
+  const attacker = new Ant('private', 0, 0, 0);
+  const target = new Ant('worker', 1, 0, 0);
+  target.hp = 2;
+  attacker.attack(target);
+  expect(target.hp).toBe(0);
+});


### PR DESCRIPTION
## Summary
- clamp damage dealt so HP never drops below zero
- add test for ant attacks to ensure HP can't go negative

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68835dd14ffc8323895fd32b4cca7f20