### PR TITLE
Fix initial game scaling

### DIFF
--- a/src/js/play.js
+++ b/src/js/play.js
@@ -222,5 +222,6 @@ function handleResize() {
 
 window.addEventListener('resize', handleResize);
 document.addEventListener('DOMContentLoaded', handleResize);
+handleResize();
 
 requestAnimationFrame(gameLoop);


### PR DESCRIPTION
## Summary
- ensure scaling handler runs once on load

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883b3363a0c8323bdf6eb4bcd4d6024