### PR TITLE
Move SUGAR_TYPES to constants

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -32,6 +32,13 @@ export const TEAM_COLORS = [
   '#FFD700'  // Team 3 - gold
 ];
 
+/* ---------- Sugar resource types ---------- */
+export const SUGAR_TYPES = [
+  { name: 'Soda Puddle',       amount: 100, rarity: 0.6 },
+  { name: 'Corn Syrup Puddle', amount: 200, rarity: 0.3 },
+  { name: 'Energy Drink',      amount: 400, rarity: 0.1 }
+];
+
 /* ---------- Helpers ---------- */
 export function dist(a, b) {
   const dx = a.x - b.x;

--- a/src/js/mapGen.js
+++ b/src/js/mapGen.js
@@ -1,4 +1,5 @@
 import mulberry32 from './prng.js';
+import { SUGAR_TYPES } from './constants.js';
 
 const TILE = 8;                  // pixel size of one map cell
 const OCTAVES = 3;
@@ -50,11 +51,6 @@ export function generateMap(width, height, seed) {
 
   // --- Sugar resources ---
   const resources = [];
-  const SUGAR_TYPES = [
-    { name: 'Soda Puddle',      amount: 100, rarity: 0.6 },
-    { name: 'Corn Syrup Puddle',amount: 200, rarity: 0.3 },
-    { name: 'Energy Drink',     amount: 400, rarity: 0.1 }
-  ];
 
   for (let attempt = 0; attempt < width * height * 0.01; attempt++) {
     const x = Math.floor(rand() * width);

--- a/tests/constants.test.js
+++ b/tests/constants.test.js
@@ -1,4 +1,4 @@
-import { dist, clamp } from '../src/js/constants.js';
+import { dist, clamp, SUGAR_TYPES } from '../src/js/constants.js';
 
 test('dist calculates Euclidean distance', () => {
   expect(dist({x:0, y:0}, {x:3, y:4})).toBe(5);
@@ -8,4 +8,9 @@ test('clamp limits values within range', () => {
   expect(clamp(5, 1, 4)).toBe(4);
   expect(clamp(-1, 0, 10)).toBe(0);
   expect(clamp(5, 0, 10)).toBe(5);
+});
+
+test('SUGAR_TYPES lists three resource types', () => {
+  expect(SUGAR_TYPES).toHaveLength(3);
+  expect(SUGAR_TYPES[0].name).toMatch(/Soda/);
 });


### PR DESCRIPTION
## Summary
- centralize sugar resource types in `constants.js`
- import `SUGAR_TYPES` from constants in `mapGen.js`
- update tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883b69058308323963227eb9b391b0b