### PR TITLE
Add facing behavior in combat

### DIFF
--- a/src/js/ant.js
+++ b/src/js/ant.js
@@ -212,6 +212,7 @@ export class Ant {
         const inRange = enemyAnts.filter(a => dist(a, nest) <= 20);
         if (inRange.length) {
           this.target = inRange[0];
+          this.dir = Math.atan2(this.target.y - this.y, this.target.x - this.x);
           const d = dist(this, this.target);
           if (d <= this.range + 0.5) {
             this.attack(this.target);
@@ -239,6 +240,7 @@ export class Ant {
             : enemyQueens[0]; // Target the first available enemy queen if no other ants
         }
         if (!this.target) break;
+        this.dir = Math.atan2(this.target.y - this.y, this.target.x - this.x);
         const d = dist(this, this.target);
         if (d <= this.range + 0.5) {
           this.attack(this.target);

--- a/tests/ant.test.js
+++ b/tests/ant.test.js
@@ -8,3 +8,17 @@ test('ant attack does not reduce hp below zero', () => {
   attacker.attack(target);
   expect(target.hp).toBe(0);
 });
+
+test('ant faces target when attacking', () => {
+  gameState.ants = [];
+  const attacker = new Ant('private', 0, 0, 0);
+  const target = new Ant('worker', 1, 0.8, 0);
+  gameState.ants.push(attacker, target);
+  attacker.state = 'defending';
+  attacker.target = target;
+
+  attacker.update(1, [], []);
+
+  const expectedDir = Math.atan2(target.y - attacker.y, target.x - attacker.x);
+  expect(attacker.dir).toBeCloseTo(expectedDir);
+});


### PR DESCRIPTION
## Summary
- rotate ants to face their target in `defending` and `attacking` states
- test that ants face their target when engaging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883c72a63cc8323a8555b9fb06a4010